### PR TITLE
feat: support importing private types

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "ts-node": "^10.2.1",
     "typescript": "^4.4.3"
   },
-  "peerDependencies": {},
   "dependencies": {
     "@aws-cdk/core": "^1.127.0",
     "aws-sdk": "^2.1004.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "ts-node": "^10.2.1",
     "typescript": "^4.4.3"
   },
+  "peerDependencies": {},
   "dependencies": {
     "@aws-cdk/core": "^1.127.0",
     "aws-sdk": "^2.1004.0",

--- a/src/cfn-registry.ts
+++ b/src/cfn-registry.ts
@@ -2,6 +2,16 @@ import * as AWS from 'aws-sdk';
 import { createAwsClient } from './aws';
 import { TypeInfo } from './type-info';
 
+export interface DescribeResourceTypeOptions {
+  /**
+   * Query with VISIBILITY=PRIVATE which means you can only import types that
+   * are registred in your account (either types that you created or public
+   * types that you activated).
+   */
+  readonly private?: boolean;
+}
+
+
 /**
  * Calls the CFN resource type registry to fetch the type definition
  *
@@ -9,8 +19,9 @@ import { TypeInfo } from './type-info';
  * @param _version the version of the type to resolve (NOT YET IMPLEMENTED)
  * @returns the type definition
  */
-export async function describeResourceType(name: string, _version?: string): Promise<TypeInfo> {
+export async function describeResourceType(name: string, _version?: string, options: DescribeResourceTypeOptions = {}): Promise<TypeInfo> {
   const cfn = createAwsClient(AWS.CloudFormation);
+  const visibility = options.private ? 'PRIVATE' : 'PUBLIC';
 
   let typeArn;
 
@@ -24,10 +35,9 @@ export async function describeResourceType(name: string, _version?: string): Pro
         NextToken: token,
         Type: name.endsWith('MODULE') ? 'MODULE' : 'RESOURCE',
         Filters: {
-          Category: 'THIRD_PARTY',
           TypeNamePrefix: name,
         },
-        Visibility: 'PUBLIC',
+        Visibility: visibility,
       }).promise();
       if (res.TypeSummaries) {
         types.push(...res.TypeSummaries);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ const args = minimist(process.argv.slice(2), {
   ],
   boolean: [
     'help',
+    'private',
   ],
   alias: {
     outdir: 'o',
@@ -29,11 +30,12 @@ function showHelp() {
   console.log('  cdk-import -l LANGUAGE RESOURCE-NAME[@VERSION]');
   console.log();
   console.log('Options:');
-  console.log('  -l, --language     Output programming language                        [string]');
-  console.log('  -o, --outdir       Output directory                                   [string]  [default: "."]');
-  console.log('  --go-module        Go module name (required if language is "golang")  [string]');
-  console.log('  --java-package     Java package name (required if language is "java") [string]');
-  console.log('  -h, --help         Show this usage info                               [boolean]');
+  console.log('  -l, --language     Output programming language                            [string]');
+  console.log('  -o, --outdir       Output directory                                       [string]  [default: "."]');
+  console.log('  --go-module        Go module name (required if language is "golang")      [string]');
+  console.log('  --java-package     Java package name (required if language is "java")     [string]');
+  console.log('  --private          Import types registered in your AWS account and region [boolean]');
+  console.log('  -h, --help         Show this usage info                                   [boolean]');
   console.log('');
   console.log('Examples:');
   console.log();
@@ -48,6 +50,9 @@ function showHelp() {
   console.log();
   console.log('  Generates construct in Java and identifies the resource type by its ARN:');
   console.log('    cdk-import -l java --java-package "com.acme.myproject" arn:aws:cloudformation:...');
+  console.log();
+  console.log('  Generates construct for a private type:');
+  console.log('    cdk-import -l typescript --private Acme::SuperService::Friend::MODULE');
   console.log();
 }
 
@@ -68,7 +73,11 @@ void (async () => {
   try {
     const [resourceName, resourceVersion] = args._[0].split('@');
     const workdir = await fs.mkdtemp(path.join(os.tmpdir(), 'cdk-import'));
-    const typeName = await importResourceType(resourceName, resourceVersion, workdir);
+    const typeName = await importResourceType(resourceName, resourceVersion, {
+      outdir: workdir,
+      private: args.private,
+    });
+
     await renderCode({
       srcdir: workdir,
       language: args.language,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,14 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { describeResourceType } from './cfn-registry';
+import { describeResourceType, DescribeResourceTypeOptions } from './cfn-registry';
 import { CfnResourceGenerator } from './cfn-resource-generator';
+
+export interface ImportResourceTypeOptions extends DescribeResourceTypeOptions {
+  /**
+   * @default "."
+   */
+  readonly outdir?: string;
+}
 
 /**
  * Entry point to import CFN resource types
@@ -11,8 +18,9 @@ import { CfnResourceGenerator } from './cfn-resource-generator';
  * @param outdir the out folder to use (defaults to the current directory)
  * @returns name of the resource type
  */
-export async function importResourceType(resourceName: string, resourceVersion: string, outdir: string = '.'): Promise<string> {
-  const type = await describeResourceType(resourceName, resourceVersion);
+export async function importResourceType(resourceName: string, resourceVersion: string, options: ImportResourceTypeOptions): Promise<string> {
+  const outdir = options.outdir ?? '.';
+  const type = await describeResourceType(resourceName, resourceVersion, options);
 
   const typeSchema = JSON.parse(type.Schema!);
 


### PR DESCRIPTION
Adds a `--private` option which can be used to generate types for private
resources and modules (types that are activated in the current AWS account and region).

Resolves #40

