### PR TITLE
feat: Add full facade and entry point for service catalog calls

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { describeResourceType, DescribeResourceTypeOptions } from './cfn-registry';
 import { CfnResourceGenerator } from './cfn-resource-generator';
+import { DescribeProductAggregateOptions, describeProductAggregate, ProductDataAggregate, fetchAvailableProducts } from './service-catalog';
 
 export interface ImportResourceTypeOptions extends DescribeResourceTypeOptions {
   /**
@@ -31,4 +32,51 @@ export async function importResourceType(resourceName: string, _resourceVersion:
   fs.writeFileSync(path.join(outdir, 'index.ts'), gen.render());
 
   return type.TypeName;
+};
+
+export interface ImportProductOptions extends DescribeProductAggregateOptions {
+  /**
+   * @default "./sc-products"
+   */
+  readonly outdir?: string;
+}
+
+/**
+ * Entry point to import Service Catalog provisioned product resource
+ *
+ * @param outdir the out folder to use (defaults to the current directory under a 'sc-products' folder)
+ * @returns the name of the provisioned product version
+ */
+export async function importProduct(options: ImportProductOptions): Promise<string> {
+  const outdir = options.outdir ?? '.';
+
+  await describeProductAggregate(options);
+
+  //TODO CodeGen
+
+  return outdir; //just for typechecking
+};
+
+/**
+ * Entry point to import all available Service Catalog provisioned product resources with `DEFAULT` paramaters.
+ *
+ * @param outdir the out folder to use (defaults to the current directory under a 'sc-products' folder)
+ * @returns the names of the provisioned product versions
+ */
+export async function importProducts(options: ImportProductOptions): Promise<string[]> {
+  const outdir = options.outdir ?? '.';
+  let productDataAggregrates: ProductDataAggregate[];
+
+  const availableProducts = await fetchAvailableProducts();
+
+  await Promise.all(availableProducts.map(async (product) => {
+    const productDataAggregate = await describeProductAggregate( {
+      productId: product.Id!,
+    });
+    productDataAggregrates.push(productDataAggregate);
+  }));
+
+  //TODO CodeGen
+
+  return [outdir]; //just for typechecking
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ export interface ImportProductOptions extends DescribeProductAggregateOptions {
 }
 
 /**
- * Entry point to import Service Catalog provisioned product resource
+ * Entry point to import Service Catalog provisioned product resource.
  *
  * @param outdir the out folder to use (defaults to the current directory under a 'sc-products' folder)
  * @returns the name of the provisioned product version

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ export async function importProduct(options: ImportProductOptions): Promise<stri
 };
 
 /**
- * Entry point to import all available Service Catalog provisioned product resources with `DEFAULT` paramaters.
+ * Entry point to import all available Service Catalog provisioned product resources with `DEFAULT` parameters.
  *
  * @param outdir the out folder to use (defaults to the current directory under a 'sc-products' folder)
  * @returns the names of the provisioned product versions

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { describeResourceType, DescribeResourceTypeOptions } from './cfn-registry';
 import { CfnResourceGenerator } from './cfn-resource-generator';
-import { DescribeProductAggregateOptions, describeProductAggregate, ProductDataAggregate, fetchAvailableProducts } from './service-catalog';
+import { describeProductAggregate, DescribeProductAggregateOptions, fetchAvailableProducts, ProductDataAggregate } from './service-catalog';
 
 export interface ImportResourceTypeOptions extends DescribeResourceTypeOptions {
   /**

--- a/src/service-catalog.ts
+++ b/src/service-catalog.ts
@@ -59,7 +59,7 @@ export interface DescribeProductAggregateOptions {
 /**
  * Returns the provisioning artifact from list of available artifacts.
  * If no query artifact Id is provided, the artifact marked `DEFAULT` will be returned.
- * If no 'DEFAULT' artifact exists, the most recently created artifact will be returned.
+ * If no `DEFAULT` artifact exists, the most recently created artifact will be returned.
  * @param provisioningArtifacts list of provisioning artifacts for a product
  * @param provisioningArtifactId query artifact Id
  * @returns provisioning artifact detail
@@ -173,7 +173,7 @@ export interface ProductDataAggregate {
   readonly product: AWS.ServiceCatalog.ProductViewSummary;
   readonly provisioningArtifact: AWS.ServiceCatalog.ProvisioningArtifact;
   readonly launchPath: AWS.ServiceCatalog.LaunchPathSummary;
-  params?: AWS.ServiceCatalog.DescribeProvisioningParametersOutput;
+  readonly params: AWS.ServiceCatalog.DescribeProvisioningParametersOutput;
 }
 
 /**

--- a/test/cfn-registry.test.ts
+++ b/test/cfn-registry.test.ts
@@ -209,7 +209,7 @@ test('should handle lookup by ARN correctly', async () => {
   expect(typeInfo.SourceUrl).toBe('https://myurl.com');
 });
 
-test('should look up private typrs if "private" is set to "true"', async () => {
+test('should look up private types if "private" is set to "true"', async () => {
   const typeName = 'Test::Resource::Type::MODULE';
   const typeArn = 'arn:aws:cloudformation:eu-central-1::type/module/uuid/Test-Resource-Type-MODULE';
 

--- a/test/service-catalog.test.ts
+++ b/test/service-catalog.test.ts
@@ -7,10 +7,7 @@ beforeEach(() => {
     searchProducts: jest.fn().mockImplementation(async () => {
       throw new Error('Not implemented');
     }),
-    listLaunchPaths: jest.fn().mockImplementation(async () => {
-      throw new Error('Not implemented');
-    }),
-    listProvisioningArtifacts: jest.fn().mockImplementation(async () => {
+    describeProduct: jest.fn().mockImplementation(async () => {
       throw new Error('Not implemented');
     }),
     describeProvisioningParameters: jest.fn().mockImplementation(async () => {
@@ -19,7 +16,7 @@ beforeEach(() => {
   };
 }),
 
-test('search products should fetch query product view summary', async () => {
+test('search products should fetch product view summaries', async () => {
   const productId = 'prod-abc123';
 
   client.searchProducts = jest.fn().mockImplementation( () => {
@@ -30,7 +27,7 @@ test('search products should fetch query product view summary', async () => {
     };
   });
 
-  const availableProducts = await testee.fetchAvailableProducts({ client: client, productId: productId });
+  const availableProducts = await testee.fetchAvailableProducts(client);
   expect(availableProducts[0].ProductId).toBe(productId);
   expect(availableProducts.length).toBe(1);
 });
@@ -58,115 +55,55 @@ test('search products should handle pagination', async () => {
     }
   });
 
-  const availableProducts = await testee.fetchAvailableProducts( { client: client });
+  const availableProducts = await testee.fetchAvailableProducts(client);
   expect(availableProducts[0].ProductId).toBe(productId1);
   expect(availableProducts[1].ProductId).toBe(productId2);
   expect(availableProducts.length).toBe(2);
 });
 
-test('list provisioning artifacts return list of provisioning artifact details', async () => {
-  const productId = 'prod-abc123';
-  const paId ='pa-abc123';
-
-  client.listProvisioningArtifacts = jest.fn().mockImplementation(async params => {
-    expect(params.ProductId).toBe(productId);
-    return {
-      ProvisioningArtifactDetails: [
-        {
-          Id: paId,
-          Name: 'v1.0',
-          Description: 'description',
-        },
-      ],
-    };
-  });
-
-  const provisioningArtifacts = await testee.listProvisioningArtifacts(productId, { client });
-  expect(provisioningArtifacts[0].Id).toBe(paId);
-  expect(provisioningArtifacts.length).toBe(1);
-});
-
-test('list provisioning artifacts returns query provisioning artifact detail', async () => {
-  const productId = 'prod-abc123';
-  const paId ='pa-abc123';
-  const queryPaId ='pa-query123';
-
-  client.listProvisioningArtifacts = jest.fn().mockImplementation(async params => {
-    expect(params.ProductId).toBe(productId);
-    return {
-      ProvisioningArtifactDetails: [
-        {
-          Id: paId,
-          Name: 'v1.0',
-          Description: 'description1',
-        },
-        {
-          Id: queryPaId,
-          Name: 'v2.0',
-          Description: 'description2',
-        },
-      ],
-    };
-  });
-
-  const provisioningArtifacts = await testee.listProvisioningArtifacts(productId, {
-    client: client,
-    provisioningArtifactId: queryPaId,
-  });
-  expect(provisioningArtifacts[0].Id).toBe(queryPaId);
-  expect(provisioningArtifacts.length).toBe(1);
-});
-
-test('list launch paths should fetch query launch path', async () => {
+test('describe product aggregate should create product data aggregate ', async () => {
   const productId = 'prod-abc123';
   const launchPathId = 'lp-abc123';
+  const provisioningArtifactId = 'pa-abc123';
+  const provisioningArtifactParameters = [
+    {
+      ParameterKey: 'Key',
+      ParameterType: 'String',
+      Description: 'Parameter Description',
+    },
+  ];
 
-  client.listLaunchPaths = jest.fn().mockImplementation(async params => {
-    expect(params.ProductId).toBe(productId);
+  client.describeProduct = jest.fn().mockImplementation( async params => {
+    expect(params.Id).toBe(productId);
     return {
-      LaunchPathSummaries: [{
+      ProductViewSummary: {
+        ProductId: productId,
+      },
+      ProvisioningArtifacts: [{
+        Id: provisioningArtifactId,
+        Name: 'v1.0',
+        Description: 'description',
+      }],
+      LaunchPaths: [{
         Id: launchPathId,
       }],
     };
   });
 
-  const launchPaths = await testee.listLaunchPaths(productId, {
-    client: client,
+  client.describeProvisioningParameters = jest.fn().mockImplementation( () => {
+    return {
+      ProvisioningArtifactParameters: provisioningArtifactParameters,
+    };
+  });
+
+  const describedProduct = await testee.describeProductAggregate( {
+    productId: productId,
     launchPathId: launchPathId,
-  });
-  expect(launchPaths[0].Id).toBe(launchPathId);
-  expect(launchPaths.length).toBe(1);
-});
-
-test('list launch paths should handle pagination', async () => {
-  const productId = 'prod-abc123';
-  const launchPathId1 = 'lp-abc123';
-  const launchPathId2 = 'lp-abc456';
-
-  client.listLaunchPaths = jest.fn().mockImplementation(async params => {
-    expect(params.ProductId).toBe(productId);
-    if (!params.PageToken) {
-      return {
-        NextPageToken: 'NextPageToken',
-        LaunchPathSummaries: [{
-          Id: launchPathId1,
-        }],
-      };
-    } else if (params.PageToken === 'NextPageToken') {
-      return {
-        LaunchPathSummaries: [{
-          Id: launchPathId2,
-        }],
-      };
-    } else {
-      throw new Error('Invalid pagination token');
-    }
+    provisioningArtifactId: provisioningArtifactId,
+    client: client,
   });
 
-  const launchPaths = await testee.listLaunchPaths(productId, { client: client });
-  expect(launchPaths[0].Id).toBe(launchPathId1);
-  expect(launchPaths[1].Id).toBe(launchPathId2);
-  expect(launchPaths.length).toBe(2);
+  expect(describedProduct.product.ProductId).toBe(productId);
 });
 
 test('should describe provisioning parameters', async () => {
@@ -187,14 +124,177 @@ test('should describe provisioning parameters', async () => {
     };
   });
 
-  const provisioningParameters = await testee.describeProvisioningParameters(
-    productId,
-    provisioningArtifactId,
-    launchPathId,
-    { client: client },
-  );
+  const provisioningParameters = await testee.describeProvisioningParameters( {
+    productId: productId,
+    provisioningArtifactId: provisioningArtifactId,
+    launchPathId: launchPathId,
+    client: client,
+  });
 
   expect(provisioningParameters.ProvisioningArtifactParameters).toBe(provisioningArtifactParameters);
+});
+
+test('describe product aggregate handle default artifact paths', async () => {
+  const productId = 'prod-abc123';
+  const provisioningArtifactId = 'pa-abc123';
+
+  client.describeProduct = jest.fn().mockImplementation( async params => {
+    expect(params.Id).toBe(productId);
+    return {
+      ProductViewSummary: {
+        ProductId: productId,
+      },
+      ProvisioningArtifacts: [
+        {
+          Id: 'pa-abc456',
+          Name: 'v2.0',
+          Description: 'description',
+        },
+        {
+          Id: provisioningArtifactId,
+          Name: 'v1.0',
+          Description: 'description',
+          Guidance: 'DEFAULT',
+        },
+      ],
+      LaunchPaths: [{
+        Id: 'lp-abc123',
+      }],
+    };
+  });
+  client.describeProvisioningParameters = jest.fn().mockImplementation( () => {
+    return {
+      ProvisioningArtifactParameters: [],
+    };
+  });
+
+  const describedProduct = await testee.describeProductAggregate( {
+    productId: productId,
+    client: client,
+  });
+
+  expect(describedProduct.product.ProductId).toBe(productId);
+  expect(describedProduct.provisioningArtifact.Id).toBe(provisioningArtifactId);
+});
+
+test('describe product aggregate handle most recently created artifact paths', async () => {
+  const productId = 'prod-abc123';
+  const provisioningArtifactId = 'pa-abc123';
+
+  client.describeProduct = jest.fn().mockImplementation( async params => {
+    expect(params.Id).toBe(productId);
+    return {
+      ProductViewSummary: {
+        ProductId: productId,
+      },
+      ProvisioningArtifacts: [
+        {
+          Id: 'pa-abc456',
+          Name: 'v2.0',
+          Description: 'description',
+          CreatedTime: '2022-02-15T16:56:31-05:00',
+        },
+        {
+          Id: provisioningArtifactId,
+          Name: 'v1.0',
+          Description: 'description',
+          CreatedTime: '2022-02-16T16:56:31-05:00',
+        },
+      ],
+      LaunchPaths: [{
+        Id: 'lp-abc123',
+      }],
+    };
+  });
+  client.describeProvisioningParameters = jest.fn().mockImplementation( () => {
+    return {
+      ProvisioningArtifactParameters: [],
+    };
+  });
+
+  const describedProduct = await testee.describeProductAggregate( {
+    productId: productId,
+    client: client,
+  });
+
+  expect(describedProduct.product.ProductId).toBe(productId);
+  expect(describedProduct.provisioningArtifact.Id).toBe(provisioningArtifactId);
+});
+
+test('describe product aggregate should resolve launch path', async () => {
+  const productId = 'prod-abc123';
+  const provisioningArtifactId = 'pa-abc123';
+  const launchPathId = 'lp-abc123';
+
+  client.describeProduct = jest.fn().mockImplementation( async params => {
+    expect(params.Id).toBe(productId);
+    return {
+      ProductViewSummary: {
+        ProductId: productId,
+      },
+      ProvisioningArtifacts: [
+        {
+          Id: 'pa-abc456',
+          Name: 'v2.0',
+          Description: 'description',
+        },
+        {
+          Id: provisioningArtifactId,
+          Name: 'v1.0',
+          Description: 'description',
+          Guidance: 'DEFAULT',
+        },
+      ],
+      LaunchPaths: [{
+        Id: launchPathId,
+      }],
+    };
+  });
+  client.describeProvisioningParameters = jest.fn().mockImplementation( () => {
+    return {
+      ProvisioningArtifactParameters: [],
+    };
+  });
+
+  const describedProduct = await testee.describeProductAggregate( {
+    productId: productId,
+    client: client,
+  });
+
+  expect(describedProduct.product.ProductId).toBe(productId);
+  expect(describedProduct.provisioningArtifact.Id).toBe(provisioningArtifactId);
+  expect(describedProduct.launchPath.Id).toBe(launchPathId);
+});
+
+test('should fail to resolvable multiple launch paths ', async () => {
+  const productId = 'prod-abc123';
+
+  client.describeProduct = jest.fn().mockImplementation( async params => {
+    expect(params.Id).toBe(productId);
+    return {
+      ProductViewSummary: {
+        ProductId: productId,
+      },
+      ProvisioningArtifacts: [
+        {
+          Id: 'pa-abc123',
+          Name: 'v1.0',
+          Description: 'description',
+        },
+      ],
+      LaunchPaths: [{
+        Id: 'lp-abc123',
+      },
+      {
+        Id: 'lp-abc456',
+      }],
+    };
+  });
+
+  await expect(testee.describeProductAggregate( {
+    productId: productId,
+    client: client,
+  })).rejects.toThrow(/Unable to resolve between multiple launch paths./);
 });
 
 afterEach(() => {


### PR DESCRIPTION
_This commit does not include any reachable code paths._

We are reducing our number of API calls here and actually removing two of them in favor
one of one call that has a larger response body but minimal latency differences.  Before we had 
list commands due to concerns over pagination but they do not have any measurable differences.

This also sets up adding both ability to describe a single product, as well as describing
all available products, which we have default paths for selecting the PA and launch path for.

Co-authored-by: Aidan Crank <arcrank@gmail.com>

