### PR TITLE
feat: complete service catalog facade and add entry points

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,8 +34,12 @@ export async function importResourceType(resourceName: string, _resourceVersion:
   return type.TypeName;
 };
 
+/**
+ * Configure options for importing products into your local workspace
+ */
 export interface ImportProductOptions extends DescribeProductAggregateOptions {
   /**
+   * The folder in which product constructs (as separate class files) will be output to.
    * @default "./sc-products"
    */
   readonly outdir?: string;
@@ -44,7 +48,6 @@ export interface ImportProductOptions extends DescribeProductAggregateOptions {
 /**
  * Entry point to import Service Catalog product resource.
  *
- * @param outdir the out folder to use (defaults to the current directory under a 'sc-products' folder)
  * @returns name of the product version
  */
 export async function importProduct(options: ImportProductOptions): Promise<string> {
@@ -60,7 +63,6 @@ export async function importProduct(options: ImportProductOptions): Promise<stri
 /**
  * Entry point to import all available Service Catalog product resources with `DEFAULT` parameters.
  *
- * @param outdir the out folder to use (defaults to the current directory under a 'sc-products' folder)
  * @returns names of the product versions
  */
 export async function importProducts(options: ImportProductOptions): Promise<string[]> {

--- a/src/service-catalog.ts
+++ b/src/service-catalog.ts
@@ -97,7 +97,13 @@ AWS.ServiceCatalog.ProvisioningArtifact {
  */
 function resolveLaunchPath(launchPaths: AWS.ServiceCatalog.LaunchPathSummaries, launchPathId?: string): AWS.ServiceCatalog.LaunchPathSummary {
   if (launchPathId) {
-    return launchPaths.filter(lp => lp.Id == launchPathId).pop()!;
+    const launchPath = launchPaths.filter(lp => lp.Id == launchPathId);
+    if (launchPath.length == 0 ) {
+      throw new Error(`Could not find specified launch path id: ${launchPathId}`);
+    } else {
+      return launchPath.pop()!;
+    }
+
   } else if (launchPaths.length == 1) {
     return launchPaths.pop()!;
   } else {
@@ -164,7 +170,7 @@ export async function fetchAvailableProducts(client?: IServiceCatalogClient): Pr
  *
  * @returns the provisoning parameters for an artifact
  */
-export async function describeProvisioningParameters( options: DescribeProductAggregateOptions):
+export async function describeProvisioningParameters(options: DescribeProductAggregateOptions):
 Promise<AWS.ServiceCatalog.DescribeProvisioningParametersOutput> {
 
   const sc = options.client ?? new ServiceCatalogClient();
@@ -209,7 +215,7 @@ export interface ProductDataAggregate {
  *
  * @returns ProductVersionData aggregate of provisioning artifact details.
  */
-export async function describeProductAggregate( options: DescribeProductAggregateOptions): Promise<ProductDataAggregate> {
+export async function describeProductAggregate(options: DescribeProductAggregateOptions): Promise<ProductDataAggregate> {
   const sc = options.client ?? new ServiceCatalogClient();
 
   const productDataAggregate = await describeProduct({

--- a/src/service-catalog.ts
+++ b/src/service-catalog.ts
@@ -3,10 +3,9 @@ import { createAwsClient } from './aws';
 
 export interface IServiceCatalogClient {
   searchProducts(input: AWS.ServiceCatalog.ListPortfoliosInput): Promise<AWS.ServiceCatalog.ListPortfoliosOutput>;
-  listProvisioningArtifacts(input: AWS.ServiceCatalog.ListProvisioningArtifactsInput): Promise<AWS.ServiceCatalog.ListProvisioningArtifactsOutput>;
-  listLaunchPaths(input: AWS.ServiceCatalog.ListLaunchPathsInput): Promise<AWS.ServiceCatalog.ListLaunchPathsOutput> ;
   describeProvisioningParameters(input: AWS.ServiceCatalog.DescribeProvisioningParametersInput):
   Promise<AWS.ServiceCatalog.DescribeProvisioningParametersOutput>;
+  describeProduct(input: AWS.ServiceCatalog.DescribeProductInput): Promise<AWS.ServiceCatalog.DescribeProductOutput>;
 }
 
 export class ServiceCatalogClient implements IServiceCatalogClient {
@@ -20,26 +19,21 @@ export class ServiceCatalogClient implements IServiceCatalogClient {
     return this.sc.searchProducts(input).promise();
   }
 
-  public async listProvisioningArtifacts(input: AWS.ServiceCatalog.ListProvisioningArtifactsInput):
-  Promise<AWS.ServiceCatalog.ListProvisioningArtifactsOutput> {
-    return this.sc.listProvisioningArtifacts(input).promise();
-  }
-
-  public async listLaunchPaths(input: AWS.ServiceCatalog.ListLaunchPathsInput): Promise<AWS.ServiceCatalog.ListLaunchPathsOutput> {
-    return this.sc.listLaunchPaths(input).promise();
-  }
-
   public async describeProvisioningParameters(input: AWS.ServiceCatalog.DescribeProvisioningParametersInput):
   Promise<AWS.ServiceCatalog.DescribeProvisioningParametersOutput> {
     return this.sc.describeProvisioningParameters(input).promise();
+  }
+
+  public async describeProduct(input: AWS.ServiceCatalog.DescribeProductInput): Promise<AWS.ServiceCatalog.DescribeProductOutput> {
+    return this.sc.describeProduct(input).promise();
   }
 }
 
 /**
  * Provide query values for a specific provisionable product.
- * If no specific IDs are declared for a product, we will use the set DEFAULT value for the provisioning artifact and launch path.
+ * If no specific IDs are declared for a product, we will use the set `DEFAULT` value for the provisioning artifact and launch path.
  */
-export interface DescribeProvisionedProductOptions {
+export interface DescribeProductAggregateOptions {
   /**
    * A client that performs calls to AWS Service Catalog. You can provide a mock here
    * for testing.
@@ -47,9 +41,9 @@ export interface DescribeProvisionedProductOptions {
   readonly client?: IServiceCatalogClient;
 
   /**
-   * The product Id..
+   * The product Id.
    */
-  readonly productId?: string;
+  readonly productId: string;
 
   /**
    * The provisioning artifact Id.
@@ -63,20 +57,81 @@ export interface DescribeProvisionedProductOptions {
 }
 
 /**
+ * Returns the provisioning artifact from list of available artifacts.
+ * If no query artifact Id is provided, the artifact marked `DEFAULT` will be returned.
+ * If no `DEFAULT` artifact exists, the most recently created artifact will be returned.
+ * @param provisioningArtifacts list of provisioning artifacts for a product
+ * @param provisioningArtifactId query artifact Id
+ * @returns provisioning artifact detail
+ */
+function resolveProvisioningArtifact(provisioningArtifacts: AWS.ServiceCatalog.ProvisioningArtifacts, provisioningArtifactId?: string):
+AWS.ServiceCatalog.ProvisioningArtifact {
+  if (provisioningArtifactId) {
+    return provisioningArtifacts.filter(pa => pa.Id == provisioningArtifactId).pop()!;
+  } else if (provisioningArtifacts.filter(pa => pa.Guidance == 'DEFAULT').length == 1) {
+    return provisioningArtifacts.filter(pa => pa.Guidance == 'DEFAULT').pop()!;
+  } else {
+    return provisioningArtifacts.sort((a, b) => a.CreatedTime!.valueOf() - b.CreatedTime!.valueOf()).pop()!;
+  }
+}
+
+/**
+ * Returns the queried launch path from list of available launch paths.
+ * @param launchPaths list of available launch paths for the product
+ * @param launchPathId the query launch path's Id
+ * @returns the launch path summary for the query launch path
+ */
+function resolveLaunchPath(launchPaths: AWS.ServiceCatalog.LaunchPathSummaries, launchPathId?: string): AWS.ServiceCatalog.LaunchPathSummary {
+  if (launchPathId) {
+    return launchPaths.filter(lp => lp.Id == launchPathId).pop()!;
+  } else if (launchPaths.length == 1) {
+    return launchPaths.pop()!;
+  } else {
+    throw new Error('Unable to resolve between multiple launch paths.');
+  }
+}
+
+/**
  * Fetches the all the available or queried service catalog product(s) for the caller.
  *
  * @returns list of product view summaries
  */
-export async function fetchAvailableProducts(options: DescribeProvisionedProductOptions = {}): Promise<AWS.ServiceCatalog.ProductViewSummaries> {
-  const sc = options.client ?? new ServiceCatalogClient();
+async function describeProduct(options: DescribeProductAggregateOptions): Promise<ProductDataAggregate> {
+  const sc: IServiceCatalogClient = options.client ?? new ServiceCatalogClient();
 
-  const products = [];
+  const describeProductResponse: AWS.ServiceCatalog.DescribeProductOutput = await sc.describeProduct({
+    Id: options.productId,
+  });
+
+  const provisioningArtifact: AWS.ServiceCatalog.ProvisioningArtifact = resolveProvisioningArtifact(describeProductResponse.ProvisioningArtifacts!,
+    options.provisioningArtifactId);
+
+  const launchPath: AWS.ServiceCatalog.LaunchPathSummary = resolveLaunchPath(describeProductResponse.LaunchPaths!, options.launchPathId);
+
+  const parameters: AWS.ServiceCatalog.DescribeProvisioningParametersOutput = await describeProvisioningParameters(options);
+
+  return {
+    product: describeProductResponse.ProductViewSummary!,
+    provisioningArtifact: provisioningArtifact,
+    launchPath: launchPath,
+    params: parameters,
+  };
+}
+
+/**
+ * Fetches all the available service catalog product(s) for the caller.
+ *
+ * @returns list of product view summaries
+ */
+export async function fetchAvailableProducts(client?: IServiceCatalogClient): Promise<AWS.ServiceCatalog.ProductViewSummaries> {
+  const sc = client ?? new ServiceCatalogClient();
+
+  const products: AWS.ServiceCatalog.ProductViewSummaries = [];
   let token;
 
   do {
     const res: AWS.ServiceCatalog.SearchProductsOutput = await sc.searchProducts({
       PageToken: token,
-      ...(options.productId ? { SourceProductId: options.productId } : {}),
     });
 
     if (res.ProductViewSummaries) {
@@ -89,81 +144,50 @@ export async function fetchAvailableProducts(options: DescribeProvisionedProduct
 }
 
 /**
- * Fetches the all the available or queried provisioning artifact(s) for the caller.
- *
- * @param productId the product to fetch provisioning artifacts for
- * @returns list of provisioning artifact details for a product
- */
-export async function listProvisioningArtifacts(
-  productId: string,
-  options: DescribeProvisionedProductOptions = {}): Promise<AWS.ServiceCatalog.ProvisioningArtifactDetail[]> {
-  const sc = options.client ?? new ServiceCatalogClient();
-
-  const provisioningArtifacts: AWS.ServiceCatalog.ListProvisioningArtifactsOutput = await sc.listProvisioningArtifacts({
-    ProductId: productId,
-  });
-
-  if ( options.provisioningArtifactId != null ) {
-    return provisioningArtifacts.ProvisioningArtifactDetails!.filter(pa => pa.Id == options.provisioningArtifactId);
-  } else {
-    return provisioningArtifacts.ProvisioningArtifactDetails!;
-  }
-}
-
-/**
- * Retrieves all the availalbe or queried launch path(s) for a product.
- *
- * @param productId the product to list launch paths for
- * @returns list of launchPathSummaries for a product
- */
-export async function listLaunchPaths(
-  productId: string,
-  options: DescribeProvisionedProductOptions = {}):
-  Promise<AWS.ServiceCatalog.LaunchPathSummaries> {
-  const sc = options.client ?? new ServiceCatalogClient();
-
-  const launchPaths = [];
-  let token;
-
-  do {
-    const res: AWS.ServiceCatalog.ListLaunchPathsOutput = await sc.listLaunchPaths({
-      ProductId: productId,
-      PageToken: token,
-    });
-
-    if (res.LaunchPathSummaries) {
-      launchPaths.push(...res.LaunchPathSummaries);
-    }
-    token = res.NextPageToken;
-  } while (token);
-
-  if ( options.launchPathId != null ) {
-    return launchPaths.filter(lp => lp.Id == options.launchPathId);
-  } else {
-    return launchPaths;
-  }
-}
-
-/**
  * Gets the information required to provision an artifact.
  * Includes information on inputs and outputs of the product.
  *
- * @param productId the product to get provisioning parameters for
- * @param provisioningArtifactId the provisioning artifact to get provisioning parameters for
- * @param launchPathId the launch path to get provisioning parameters for
  * @returns the provisoning parameters for an artifact
  */
-export async function describeProvisioningParameters(productId: string, provisioningArtifactId: string, launchPathId: string,
-  options: DescribeProvisionedProductOptions = {}):
-  Promise<AWS.ServiceCatalog.DescribeProvisioningParametersOutput> {
+export async function describeProvisioningParameters(options: DescribeProductAggregateOptions):
+Promise<AWS.ServiceCatalog.DescribeProvisioningParametersOutput> {
 
   const sc = options.client ?? new ServiceCatalogClient();
 
   const provisioningParameters: AWS.ServiceCatalog.DescribeProvisioningParametersOutput = await sc.describeProvisioningParameters({
-    ProductId: productId,
-    ProvisioningArtifactId: provisioningArtifactId,
-    PathId: launchPathId,
+    ProductId: options.productId,
+    ProvisioningArtifactId: options.provisioningArtifactId,
+    PathId: options.launchPathId,
   });
 
   return provisioningParameters;
+}
+
+/**
+ * Holds all the information needed to generate a product artifact to provision.
+ */
+export interface ProductDataAggregate {
+  readonly product: AWS.ServiceCatalog.ProductViewSummary;
+  readonly provisioningArtifact: AWS.ServiceCatalog.ProvisioningArtifact;
+  readonly launchPath: AWS.ServiceCatalog.LaunchPathSummary;
+  readonly params: AWS.ServiceCatalog.DescribeProvisioningParametersOutput;
+}
+
+/**
+ * Makes a series of calls to service catalog to get all information
+ * required to provision a service catalog product.
+ *
+ * @returns ProductVersionData aggregate of provisioning artifact details.
+ */
+export async function describeProductAggregate( options: DescribeProductAggregateOptions): Promise<ProductDataAggregate> {
+  const sc = options.client ?? new ServiceCatalogClient();
+
+  const productDataAggregate = await describeProduct({
+    productId: options.productId!,
+    launchPathId: options.launchPathId,
+    provisioningArtifactId: options.provisioningArtifactId,
+    client: sc,
+  });
+
+  return productDataAggregate;
 }

--- a/test/service-catalog.test.ts
+++ b/test/service-catalog.test.ts
@@ -3,14 +3,12 @@ import * as testee from '../src/service-catalog';
 let client: testee.IServiceCatalogClient;
 
 beforeEach(() => {
+
   client = {
     searchProducts: jest.fn().mockImplementation(async () => {
       throw new Error('Not implemented');
     }),
-    listLaunchPaths: jest.fn().mockImplementation(async () => {
-      throw new Error('Not implemented');
-    }),
-    listProvisioningArtifacts: jest.fn().mockImplementation(async () => {
+    describeProduct: jest.fn().mockImplementation(async () => {
       throw new Error('Not implemented');
     }),
     describeProvisioningParameters: jest.fn().mockImplementation(async () => {
@@ -19,7 +17,7 @@ beforeEach(() => {
   };
 }),
 
-test('search products should fetch query product view summary', async () => {
+test('search products should fetch product view summaries', async () => {
   const productId = 'prod-abc123';
 
   client.searchProducts = jest.fn().mockImplementation( () => {
@@ -30,7 +28,7 @@ test('search products should fetch query product view summary', async () => {
     };
   });
 
-  const availableProducts = await testee.fetchAvailableProducts({ client: client, productId: productId });
+  const availableProducts = await testee.fetchAvailableProducts(client);
   expect(availableProducts[0].ProductId).toBe(productId);
   expect(availableProducts.length).toBe(1);
 });
@@ -58,115 +56,55 @@ test('search products should handle pagination', async () => {
     }
   });
 
-  const availableProducts = await testee.fetchAvailableProducts( { client: client });
+  const availableProducts = await testee.fetchAvailableProducts(client);
   expect(availableProducts[0].ProductId).toBe(productId1);
   expect(availableProducts[1].ProductId).toBe(productId2);
   expect(availableProducts.length).toBe(2);
 });
 
-test('list provisioning artifacts return list of provisioning artifact details', async () => {
-  const productId = 'prod-abc123';
-  const paId ='pa-abc123';
-
-  client.listProvisioningArtifacts = jest.fn().mockImplementation(async params => {
-    expect(params.ProductId).toBe(productId);
-    return {
-      ProvisioningArtifactDetails: [
-        {
-          Id: paId,
-          Name: 'v1.0',
-          Description: 'description',
-        },
-      ],
-    };
-  });
-
-  const provisioningArtifacts = await testee.listProvisioningArtifacts(productId, { client });
-  expect(provisioningArtifacts[0].Id).toBe(paId);
-  expect(provisioningArtifacts.length).toBe(1);
-});
-
-test('list provisioning artifacts returns query provisioning artifact detail', async () => {
-  const productId = 'prod-abc123';
-  const paId ='pa-abc123';
-  const queryPaId ='pa-query123';
-
-  client.listProvisioningArtifacts = jest.fn().mockImplementation(async params => {
-    expect(params.ProductId).toBe(productId);
-    return {
-      ProvisioningArtifactDetails: [
-        {
-          Id: paId,
-          Name: 'v1.0',
-          Description: 'description1',
-        },
-        {
-          Id: queryPaId,
-          Name: 'v2.0',
-          Description: 'description2',
-        },
-      ],
-    };
-  });
-
-  const provisioningArtifacts = await testee.listProvisioningArtifacts(productId, {
-    client: client,
-    provisioningArtifactId: queryPaId,
-  });
-  expect(provisioningArtifacts[0].Id).toBe(queryPaId);
-  expect(provisioningArtifacts.length).toBe(1);
-});
-
-test('list launch paths should fetch query launch path', async () => {
+test('describe product aggregate should create product data aggregate ', async () => {
   const productId = 'prod-abc123';
   const launchPathId = 'lp-abc123';
+  const provisioningArtifactId = 'pa-abc123';
+  const provisioningArtifactParameters = [
+    {
+      ParameterKey: 'Key',
+      ParameterType: 'String',
+      Description: 'Parameter Description',
+    },
+  ];
 
-  client.listLaunchPaths = jest.fn().mockImplementation(async params => {
-    expect(params.ProductId).toBe(productId);
+  client.describeProduct = jest.fn().mockImplementation( async params => {
+    expect(params.Id).toBe(productId);
     return {
-      LaunchPathSummaries: [{
+      ProductViewSummary: {
+        ProductId: productId,
+      },
+      ProvisioningArtifacts: [{
+        Id: provisioningArtifactId,
+        Name: 'v1.0',
+        Description: 'description',
+      }],
+      LaunchPaths: [{
         Id: launchPathId,
       }],
     };
   });
 
-  const launchPaths = await testee.listLaunchPaths(productId, {
-    client: client,
+  client.describeProvisioningParameters = jest.fn().mockImplementation( () => {
+    return {
+      ProvisioningArtifactParameters: provisioningArtifactParameters,
+    };
+  });
+
+  const describedProduct = await testee.describeProductAggregate( {
+    productId: productId,
     launchPathId: launchPathId,
-  });
-  expect(launchPaths[0].Id).toBe(launchPathId);
-  expect(launchPaths.length).toBe(1);
-});
-
-test('list launch paths should handle pagination', async () => {
-  const productId = 'prod-abc123';
-  const launchPathId1 = 'lp-abc123';
-  const launchPathId2 = 'lp-abc456';
-
-  client.listLaunchPaths = jest.fn().mockImplementation(async params => {
-    expect(params.ProductId).toBe(productId);
-    if (!params.PageToken) {
-      return {
-        NextPageToken: 'NextPageToken',
-        LaunchPathSummaries: [{
-          Id: launchPathId1,
-        }],
-      };
-    } else if (params.PageToken === 'NextPageToken') {
-      return {
-        LaunchPathSummaries: [{
-          Id: launchPathId2,
-        }],
-      };
-    } else {
-      throw new Error('Invalid pagination token');
-    }
+    provisioningArtifactId: provisioningArtifactId,
+    client: client,
   });
 
-  const launchPaths = await testee.listLaunchPaths(productId, { client: client });
-  expect(launchPaths[0].Id).toBe(launchPathId1);
-  expect(launchPaths[1].Id).toBe(launchPathId2);
-  expect(launchPaths.length).toBe(2);
+  expect(describedProduct.product.ProductId).toBe(productId);
 });
 
 test('should describe provisioning parameters', async () => {
@@ -187,14 +125,177 @@ test('should describe provisioning parameters', async () => {
     };
   });
 
-  const provisioningParameters = await testee.describeProvisioningParameters(
-    productId,
-    provisioningArtifactId,
-    launchPathId,
-    { client: client },
-  );
+  const provisioningParameters = await testee.describeProvisioningParameters( {
+    productId: productId,
+    provisioningArtifactId: provisioningArtifactId,
+    launchPathId: launchPathId,
+    client: client,
+  });
 
   expect(provisioningParameters.ProvisioningArtifactParameters).toBe(provisioningArtifactParameters);
+});
+
+test('describe product aggregate handle default artifact paths', async () => {
+  const productId = 'prod-abc123';
+  const provisioningArtifactId = 'pa-abc123';
+
+  client.describeProduct = jest.fn().mockImplementation( async params => {
+    expect(params.Id).toBe(productId);
+    return {
+      ProductViewSummary: {
+        ProductId: productId,
+      },
+      ProvisioningArtifacts: [
+        {
+          Id: 'pa-abc456',
+          Name: 'v2.0',
+          Description: 'description',
+        },
+        {
+          Id: provisioningArtifactId,
+          Name: 'v1.0',
+          Description: 'description',
+          Guidance: 'DEFAULT',
+        },
+      ],
+      LaunchPaths: [{
+        Id: 'lp-abc123',
+      }],
+    };
+  });
+  client.describeProvisioningParameters = jest.fn().mockImplementation( () => {
+    return {
+      ProvisioningArtifactParameters: [],
+    };
+  });
+
+  const describedProduct = await testee.describeProductAggregate( {
+    productId: productId,
+    client: client,
+  });
+
+  expect(describedProduct.product.ProductId).toBe(productId);
+  expect(describedProduct.provisioningArtifact.Id).toBe(provisioningArtifactId);
+});
+
+test('describe product aggregate handle most recently created artifact paths', async () => {
+  const productId = 'prod-abc123';
+  const provisioningArtifactId = 'pa-abc123';
+
+  client.describeProduct = jest.fn().mockImplementation( async params => {
+    expect(params.Id).toBe(productId);
+    return {
+      ProductViewSummary: {
+        ProductId: productId,
+      },
+      ProvisioningArtifacts: [
+        {
+          Id: 'pa-abc456',
+          Name: 'v2.0',
+          Description: 'description',
+          CreatedTime: new Date('2022-02-15T16:56:31-05:00'),
+        },
+        {
+          Id: provisioningArtifactId,
+          Name: 'v1.0',
+          Description: 'description',
+          CreatedTime: new Date('2022-02-16T16:56:31-05:00'),
+        },
+      ],
+      LaunchPaths: [{
+        Id: 'lp-abc123',
+      }],
+    };
+  });
+  client.describeProvisioningParameters = jest.fn().mockImplementation( () => {
+    return {
+      ProvisioningArtifactParameters: [],
+    };
+  });
+
+  const describedProduct = await testee.describeProductAggregate( {
+    productId: productId,
+    client: client,
+  });
+
+  expect(describedProduct.product.ProductId).toBe(productId);
+  expect(describedProduct.provisioningArtifact.Id).toBe(provisioningArtifactId);
+});
+
+test('describe product aggregate should resolve launch path', async () => {
+  const productId = 'prod-abc123';
+  const provisioningArtifactId = 'pa-abc123';
+  const launchPathId = 'lp-abc123';
+
+  client.describeProduct = jest.fn().mockImplementation( async params => {
+    expect(params.Id).toBe(productId);
+    return {
+      ProductViewSummary: {
+        ProductId: productId,
+      },
+      ProvisioningArtifacts: [
+        {
+          Id: 'pa-abc456',
+          Name: 'v2.0',
+          Description: 'description',
+        },
+        {
+          Id: provisioningArtifactId,
+          Name: 'v1.0',
+          Description: 'description',
+          Guidance: 'DEFAULT',
+        },
+      ],
+      LaunchPaths: [{
+        Id: launchPathId,
+      }],
+    };
+  });
+  client.describeProvisioningParameters = jest.fn().mockImplementation( () => {
+    return {
+      ProvisioningArtifactParameters: [],
+    };
+  });
+
+  const describedProduct = await testee.describeProductAggregate( {
+    productId: productId,
+    client: client,
+  });
+
+  expect(describedProduct.product.ProductId).toBe(productId);
+  expect(describedProduct.provisioningArtifact.Id).toBe(provisioningArtifactId);
+  expect(describedProduct.launchPath.Id).toBe(launchPathId);
+});
+
+test('should fail to resolvable multiple launch paths ', async () => {
+  const productId = 'prod-abc123';
+
+  client.describeProduct = jest.fn().mockImplementation( async params => {
+    expect(params.Id).toBe(productId);
+    return {
+      ProductViewSummary: {
+        ProductId: productId,
+      },
+      ProvisioningArtifacts: [
+        {
+          Id: 'pa-abc123',
+          Name: 'v1.0',
+          Description: 'description',
+        },
+      ],
+      LaunchPaths: [{
+        Id: 'lp-abc123',
+      },
+      {
+        Id: 'lp-abc456',
+      }],
+    };
+  });
+
+  await expect(testee.describeProductAggregate( {
+    productId: productId,
+    client: client,
+  })).rejects.toThrow(/Unable to resolve between multiple launch paths./);
 });
 
 afterEach(() => {

--- a/test/service-catalog.test.ts
+++ b/test/service-catalog.test.ts
@@ -149,6 +149,36 @@ test('should throw error if no provisioning artifacts found', async () => {
   })).rejects.toThrow(/Cannot resolve provisioning artifacts for product: /);
 });
 
+test('should throw error query launch path not found', async () => {
+  const productId = 'prod-abc123';
+  const launchPathId = 'lp-abc123';
+
+  client.describeProduct = jest.fn().mockImplementation( async params => {
+    expect(params.Id).toBe(productId);
+    return {
+      ProductViewSummary: {
+        ProductId: productId,
+      },
+      ProvisioningArtifacts: [
+        {
+          Id: 'pa-abc456',
+          Name: 'v2.0',
+          Description: 'description',
+        },
+      ],
+      LaunchPaths: [{
+        Id: 'lp-abc456',
+      }],
+    };
+  });
+
+  await expect(testee.describeProductAggregate( {
+    productId: productId,
+    launchPathId: launchPathId,
+    client: client,
+  })).rejects.toThrow(/Could not find specified launch path id:/);
+});
+
 test('should throw error if no launch paths found', async () => {
   const productId = 'prod-abc123';
 


### PR DESCRIPTION
_This does not add any reachable code paths._

Clean up facade/client to use fewer API calls.
Add entry point to import a single product and all available.
Add logic for resolving default ProvisioningArtifacts and LaunchPaths.



Co-authored-by: Aidan Crank <arcrank@gmail.com>