### PR TITLE
feat: add validation for supported synthesizers in sc codegen

### DIFF
--- a/src/sc-construct-generator.ts
+++ b/src/sc-construct-generator.ts
@@ -209,6 +209,15 @@ export class ServiceCatalogProvisioningConstructGenerator {
     code.line(' */');
   }
 
+  private emitSynthesizerValidation(code: j2j.Code) {
+    code.line('const synthesizer: cdk.IStackSynthesizer = cdk.Stack.of(this).synthesizer;');
+    code.line('const supportedSynthesizers = [cdk.CliCredentialsStackSynthesizer, cdk.LegacyStackSynthesizer, cdk.BootstraplessSynthesizer];');
+    code.line();
+    code.line('if (!supportedSynthesizers.some(supportedSynthesizer => synthesizer instanceof supportedSynthesizer)) {');
+    code.line('  throw Error(`${synthesizer.constructor.name} not supported. Please use one of the supported synthesizers: ${supportedSynthesizers.map(synth => synth.name)}`);');
+    code.line('}');
+  }
+
   private emitConstructClass(code: j2j.Code) {
     this.emitProductDescription(code);
     code.openBlock(`export class ${this.constructClassName} extends ${this.constructClassName}Base`);
@@ -234,7 +243,9 @@ export class ServiceCatalogProvisioningConstructGenerator {
     code.line(' */');
     code.openBlock(`constructor(scope: constructs.Construct, id: string${this.hasParameters ? ', props: ' + this.propsStructName : ''})`);
     code.line('super(scope, id);');
-    code.line('');
+    code.line();
+    this.emitSynthesizerValidation(code);
+    code.line();
     code.line("this.provisionedProduct = new sc.CfnCloudFormationProvisionedProduct(this, 'Resource', {");
     code.line('  provisionedProductName: this.node.id,');
 

--- a/test/__snapshots__/sc-construct-generator.test.ts.snap
+++ b/test/__snapshots__/sc-construct-generator.test.ts.snap
@@ -108,6 +108,13 @@ export class AiPoweredHealthDataMasking extends AiPoweredHealthDataMaskingBase {
   constructor(scope: constructs.Construct, id: string) {
     super(scope, id);
 
+    const synthesizer: cdk.IStackSynthesizer = cdk.Stack.of(this).synthesizer;
+    const supportedSynthesizers = [cdk.CliCredentialsStackSynthesizer, cdk.LegacyStackSynthesizer, cdk.BootstraplessSynthesizer];
+
+    if (!supportedSynthesizers.some(supportedSynthesizer => synthesizer instanceof supportedSynthesizer)) {
+      throw Error(\`\${synthesizer.constructor.name} not supported. Please use one of the supported synthesizers: \${supportedSynthesizers.map(synth => synth.name)}\`);
+    }
+
     this.provisionedProduct = new sc.CfnCloudFormationProvisionedProduct(this, 'Resource', {
       provisionedProductName: this.node.id,
       provisioningArtifactName: 'v1.0',
@@ -172,6 +179,13 @@ export class BucketProduct extends BucketProductBase {
    */
   constructor(scope: constructs.Construct, id: string) {
     super(scope, id);
+
+    const synthesizer: cdk.IStackSynthesizer = cdk.Stack.of(this).synthesizer;
+    const supportedSynthesizers = [cdk.CliCredentialsStackSynthesizer, cdk.LegacyStackSynthesizer, cdk.BootstraplessSynthesizer];
+
+    if (!supportedSynthesizers.some(supportedSynthesizer => synthesizer instanceof supportedSynthesizer)) {
+      throw Error(\`\${synthesizer.constructor.name} not supported. Please use one of the supported synthesizers: \${supportedSynthesizers.map(synth => synth.name)}\`);
+    }
 
     this.provisionedProduct = new sc.CfnCloudFormationProvisionedProduct(this, 'Resource', {
       provisionedProductName: this.node.id,
@@ -286,6 +300,13 @@ export class Ec2ComputeInstance extends Ec2ComputeInstanceBase {
    */
   constructor(scope: constructs.Construct, id: string, props: Ec2ComputeInstanceProps) {
     super(scope, id);
+
+    const synthesizer: cdk.IStackSynthesizer = cdk.Stack.of(this).synthesizer;
+    const supportedSynthesizers = [cdk.CliCredentialsStackSynthesizer, cdk.LegacyStackSynthesizer, cdk.BootstraplessSynthesizer];
+
+    if (!supportedSynthesizers.some(supportedSynthesizer => synthesizer instanceof supportedSynthesizer)) {
+      throw Error(\`\${synthesizer.constructor.name} not supported. Please use one of the supported synthesizers: \${supportedSynthesizers.map(synth => synth.name)}\`);
+    }
 
     this.provisionedProduct = new sc.CfnCloudFormationProvisionedProduct(this, 'Resource', {
       provisionedProductName: this.node.id,


### PR DESCRIPTION
_This does not add any active code paths._

For cdk v2, using a service catalog provisioning construct does not
make sense for the standard case with the DefaultStackSynthesizer as the cdk bootstrap roles
will invoke Service Catalog to provision the product and will not have
the correct permissions or associations. This change will add that validation
to the codegen so it can fail at synth time instead of during deployment.

Co-authored-by: Aidan Crank <arcrank@gmail.com>

