### PR TITLE
chore: Add and upgrade dependencies

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -87,11 +87,20 @@
       "type": "build"
     },
     {
+      "name": "aws-cdk-lib",
+      "type": "runtime"
+    },
+    {
       "name": "aws-sdk",
       "type": "runtime"
     },
     {
       "name": "case",
+      "type": "runtime"
+    },
+    {
+      "name": "constructs",
+      "version": "^10",
       "type": "runtime"
     },
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -5,7 +5,9 @@ const project = new typescript.TypeScriptProject({
   defaultReleaseBranch: 'main',
   deps: [
     'json2jsii',
+    'aws-cdk-lib',
     'aws-sdk',
+    'constructs@^10',
     'minimist',
     'minimist-subcommand',
     'proxy-agent',

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ There are currently two sources that resources can be generated from. The subcom
 `cfn` is used to import from CloudFormation Registry, 
 `sc` is used to import AWS Service Catalog products.
 There are shared general options for output directories and target language.
+You will need `AWS_REGION` variable configured in your environment.
 
 ```shell
 Usage:
@@ -165,9 +166,9 @@ cdk-import cfn AWSQS::CheckPoint::CloudGuardQS::MODULE
 
 ## AWS Service Catalog Usage
 
-The cdk-import tool generates a user friendly version of a provisioned product
-that can be used like a normal cdk construct within a cdk app.
-You can currently either specify a specific product version or generate all available products
+The cdk-import tool generates a user friendly version of a provisioned product that becomes 
+a normal cdk construct that you can use within a cdk app.
+You can currently either specify a specific product version or generate all available products.
 The tool will call APIs and attempt to resolve default artifact and launch path for a product,
 if a singular product version or launch path cannot be resolved, it will throw an error.
 You will need Service Catalog end-user read permissions to call these APIs. 
@@ -197,6 +198,14 @@ If you are using `csharp`, you must specify a `--csharp-namespace` within your p
 
 Output will be generated relative to `--outdir` which defaults to the current
 working directory under `./sc-products`.
+
+## Examples
+
+Generates constructs in python for the latest product versions as importable modules in your local workspace.
+
+```shell
+cdk-import sc -l python -o .
+```
 
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -40,17 +40,19 @@
     "jest-junit": "^13",
     "json-schema": "^0.4.0",
     "npm-check-updates": "^12",
-    "projen": "^0.55.6",
+    "projen": "^0.55.7",
     "standard-version": "^9",
     "ts-jest": "^27",
     "ts-node": "^10.7.0",
     "typescript": "^4.6.4"
   },
   "dependencies": {
+    "aws-cdk-lib": "^2.23.0",
     "aws-sdk": "^2.1128.0",
     "case": "^1.6.3",
+    "constructs": "^10",
     "jsii-srcmak": "^0.1.549",
-    "json2jsii": "^0.3.2",
+    "json2jsii": "^0.3.3",
     "minimist": "^1.2.6",
     "minimist-subcommand": "^3.0.2",
     "proxy-agent": "^5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1454,9 +1454,9 @@ camelcase@^6.2.0, camelcase@^6.3.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001332:
-  version "1.0.30001335"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001335.tgz#899254a0b70579e5a957c32dced79f0727c61f2a"
-  integrity sha512-ddP1Tgm7z2iIxu6QTtbZUv6HJxSaV/PZeSrWFZtbY4JZ69tOeNhBCl3HyRQgeNZKE5AOn1kpV7fhljigy0Ty3w==
+  version "1.0.30001336"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001336.tgz#a9eb13edd2613f418ebc632c8d6c9ab9fde7ccc4"
+  integrity sha512-/YxSlBmL7iKXTbIJ48IQTnAOBk7XmWsxhBF1PZLOko5Dt9qc4Pl+84lfqG3Tc4EuavurRn1QLoVJGxY2iSycfw==
 
 case@1.6.3, case@^1.6.3:
   version "1.6.3"
@@ -2153,9 +2153,9 @@ duplexer3@^0.1.4:
   integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
 
 electron-to-chromium@^1.4.118:
-  version "1.4.133"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.133.tgz#d63d060b874d289f0555fd1db23c7e018d0a18cb"
-  integrity sha512-ZiIO/VXWqY9WME7vztTySSqwm4+A8o66upAb4AmxPwOLejUM8dffcDKY+Hj6oBq/1de7w75n4GxYFxF52ewnUQ==
+  version "1.4.134"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.134.tgz#9baca7a018ca489d8e81a00c7cfe15161da38568"
+  integrity sha512-OdD7M2no4Mi8PopfvoOuNcwYDJ2mNFxaBfurA6okG3fLBaMcFah9S+si84FhX+FIWLKkdaiHfl4A+5ep/gOVrg==
 
 emittery@^0.8.1:
   version "0.8.1"
@@ -4116,10 +4116,10 @@ json-stringify-safe@^5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json2jsii@^0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/json2jsii/-/json2jsii-0.3.2.tgz#d5dcd3ba7829b89a8ef5db044e878197352f0651"
-  integrity sha512-RAmR/eVudx/3gm6VKHisFUKGcPglmcKPt0pXO1QbUtc1ZFy9nFZuPzPpQaAamexZwcM5MaK1ZeWXHzoEwFqYTg==
+json2jsii@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/json2jsii/-/json2jsii-0.3.3.tgz#a20be990bb30d894d67e51eefc88e97c3a7f6d66"
+  integrity sha512-T0YZWIED/BEybd+eViJVygst6oElNq00NVUuFFz+/fVdkYVVTrA9SdDk9eOCUm5Z9Cuv4N2V38ZLkJxMH52kOw==
   dependencies:
     camelcase "^6.3.0"
     json-schema "^0.4.0"
@@ -5166,10 +5166,10 @@ progress@^2.0.3:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-projen@^0.55.6:
-  version "0.55.6"
-  resolved "https://registry.yarnpkg.com/projen/-/projen-0.55.6.tgz#245a50498dadbacf4c6d92b3d07220f7fc6b3968"
-  integrity sha512-/aT58df40fF/GKam3LUAASViuhj8N1rP2pA8BAtAVgV4zvnwxZKa3D3fZNdL4XfeC9w+dgMS3c8VzatGJLMIwg==
+projen@^0.55.7:
+  version "0.55.7"
+  resolved "https://registry.yarnpkg.com/projen/-/projen-0.55.7.tgz#d6e90299e613054b461a7d6488656e774fecb04a"
+  integrity sha512-/I0FMtkF3YU4A9uoYNxm13cer1vwdFDwvnQ77BHsmyPSj2wNh1OiIvfqTSfM9NlrNCpOsehC6HfppeH79OysiQ==
   dependencies:
     "@iarna/toml" "^2.2.5"
     case "^1.6.3"


### PR DESCRIPTION
We need `aws-cdk-lib` and `constructs` in our codegen files because we are rendering
an L2 that has an L1 resource in it.

Due to jsii packaging we need these in dependencies otherwise a fresh install of the tool will
fail if you do not have aws-cdk-lib installed.

Also added blip on configuring `AWS_REGION`

Add small python example for SC

Fixes #