### PR TITLE
feat: support generating CFN constructs from local schema files

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ npm install -g cdk-import
 
 ## Usage
 
-There are currently two sources that resources can be generated from. The subcommand 
-`cfn` is used to import from CloudFormation Registry, 
+There are currently two sources that resources can be generated from. The subcommand
+`cfn` is used to import from CloudFormation Registry,
 `sc` is used to import AWS Service Catalog products.
 There are shared general options for output directories and target language.
 You will need `AWS_REGION` variable configured in your environment.
@@ -44,6 +44,7 @@ Usage:
 Options:
   -l, --language     Output programming language                        [string]
   -o, --outdir       Output directory                                   [string]  [default: "."]
+  -s, --schema-file  Read schema from a file (instead of CFN registry)  [string]
   --go-module        Module name (required if language is "golang")     [string]
   --java-package     Java package name (required if language is "java") [string]
   --csharp-namespace C# namespace (optional if language is "csharp",    [string]
@@ -56,6 +57,13 @@ languages: `typescript`, `java`, `python`, `csharp` and `golang`.
 
 Output will be generated relative to `--outdir` which defaults to the current
 working directory.
+
+By default, the resource schema will be read from the AWS CloudFormation Registry,
+using the current AWS credentials (configured using environment variables). If
+you have a copy of the JSON schema that describes the resource properties
+in a local file, you can pass `--schema-file` to specify the file. This will
+bypass the query to the CloudFormation Registry. It expects the exact same
+`Schema` contents as returned by `DescribeType`.
 
 The following section describes language-specific behavior.
 
@@ -86,7 +94,7 @@ is based on the name of the resource (`AWSQS::EKS::Cluster` =>
 For example:
 
 ```shell
-cdk-import -l python AWSQS::EKS::Cluster 
+cdk-import -l python AWSQS::EKS::Cluster
 ```
 
 Will generate a subdirectory `awsqs_eks_cluster` with a Python module that can
@@ -100,7 +108,7 @@ resource name (`AWSQS::EKS::Cluster`).
 For example:
 
 ```shell
-cdk-import -l csharp AWSQS::EKS::Cluster 
+cdk-import -l csharp AWSQS::EKS::Cluster
 ```
 
 Will generate a directory `AWSQS::EKS::Cluster` with a `.csproj`. This can be
@@ -170,12 +178,12 @@ cdk-import cfn AWSQS::CheckPoint::CloudGuardQS::MODULE
 
 ## AWS Service Catalog Usage
 
-The cdk-import tool generates a user friendly version of a provisioned product that becomes 
+The cdk-import tool generates a user friendly version of a provisioned product that becomes
 a normal cdk construct that you can use within a cdk app.
 You can currently either specify a specific product version or generate all available products.
 The tool will call APIs and attempt to resolve default artifact and launch path for a product,
 if a singular product version or launch path cannot be resolved, it will throw an error.
-You will need Service Catalog end-user read permissions to call these APIs. 
+You will need Service Catalog end-user read permissions to call these APIs.
 
 ```shell
 Usage:

--- a/src/cfn-resource-generator.ts
+++ b/src/cfn-resource-generator.ts
@@ -21,7 +21,7 @@ export class CfnResourceGenerator {
    * @param typeDef the type info containing the source url
    * @param schema the schema of the resource type for input and output properties
    */
-  constructor(private readonly typeName: string, private readonly typeDef: TypeInfo, private readonly schema: any) {
+  constructor(private readonly typeName: string, private readonly typeDef: TypeInfo | undefined, private readonly schema: any) {
     this.sanitizedTypeName = sanitizeTypeName(typeName);
     // this.resourceAttributes = this.schema.readOnlyProperties ? this.schema.readOnlyProperties.map((prop: string) => prop.replace(/^\/properties\//, '')) : [];
     // this.resourceProperties = Object.keys(this.schema.properties).filter(prop => this.resourceAttributes.indexOf(prop) === -1);
@@ -106,7 +106,7 @@ export class CfnResourceGenerator {
     code.line(' *');
     code.line(` * @cloudformationResource ${this.typeName}`);
     code.line(' * @stability external');
-    if (this.typeDef.SourceUrl) {
+    if (this.typeDef?.SourceUrl) {
       code.line(` * @link ${this.typeDef.SourceUrl}`);
     }
     code.line(' */');
@@ -127,7 +127,7 @@ export class CfnResourceGenerator {
     for (const prop of this.resourceAttributes) {
       code.line('/**');
       code.line(` * Attribute \`${this.typeName}.${prop}\``);
-      if (this.typeDef.SourceUrl) {
+      if (this.typeDef?.SourceUrl) {
         code.line(` * @link ${this.typeDef.SourceUrl}`);
       }
       code.line(' */');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,8 +5,9 @@ import * as path from 'path';
 import * as caseutil from 'case';
 import minimist from 'minimist';
 import { parseCommands } from 'minimist-subcommand';
-import { importResourceType, importProducts, importProduct } from '.';
+import { importResourceType, importProducts, importProduct, readResourceDefinitionFromRegistry } from '.';
 import { renderCode, SUPPORTED_LANGUAGES } from './languages';
+import { TypeInfo } from './type-info';
 
 const commandDefintion = {
   commands: {
@@ -26,6 +27,7 @@ const args = minimist(parsedCommandsAndArgv.argv, {
     'product-id',
     'provisioning-artifact-id',
     'path-id',
+    'schema-file',
   ],
   boolean: [
     'help',
@@ -33,6 +35,7 @@ const args = minimist(parsedCommandsAndArgv.argv, {
   ],
   alias: {
     outdir: 'o',
+    'schema-file': 's',
     help: 'h',
     language: 'l',
   },
@@ -46,6 +49,7 @@ function showHelp() {
   console.log('General options:');
   console.log('  -l, --language     Output programming language                               [string]');
   console.log('  -o, --outdir       Output directory                                          [string]');
+  console.log('  -s, --schema-file  Read schema from a file (instead of CFN registry)         [string]');
   console.log('  --go-module        Go module name (required if language is "golang")         [string]');
   console.log('  --java-package     Java package name (required if language is "java")        [string]');
   console.log('  --csharp-namespace C# namespace (optional if language is "csharp",           [string]');
@@ -63,6 +67,7 @@ function showCfnHelp() {
   console.log('Options:');
   console.log('  -l, --language     Output programming language                            [string]');
   console.log('  -o, --outdir       Output directory                                       [string]  [default: "."]');
+  console.log('  -s, --schema-file  Read schema from a file (instead of CFN registry)      [string]');
   console.log('  --go-module        Go module name (required if language is "golang")      [string]');
   console.log('  --java-package     Java package name (required if language is "java")     [string]');
   console.log('  --csharp-namespace C# namespace (optional if language is "csharp",        [string]');
@@ -122,6 +127,14 @@ function showSCHelp() {
 }
 
 void (async () => {
+  if (args.help && subCommand === 'cfn')  {
+    showCfnHelp();
+    process.exit(1);
+  }
+  if (args.help && subCommand === 'sc')  {
+    showSCHelp();
+    process.exit(1);
+  }
   if (args.help || !subCommand) {
     showHelp();
     process.exit(1);
@@ -144,9 +157,21 @@ void (async () => {
     try {
       const [resourceName, resourceVersion] = args._[0].split('@');
       const workdir = await fs.mkdtemp(path.join(os.tmpdir(), 'cdk-import'));
-      const typeName = await importResourceType(resourceName, resourceVersion, {
-        outdir: workdir,
-        private: args.private,
+
+      let typeInfo: TypeInfo;
+      if (args['schema-file']) {
+        typeInfo = {
+          TypeName: resourceName,
+          Schema: await fs.readFile(args['schema-file'], { encoding: 'utf-8' }),
+        };
+      } else {
+        typeInfo = await readResourceDefinitionFromRegistry(resourceName, resourceVersion, {
+          private: args.private,
+        });
+      }
+
+      const typeName = importResourceType(typeInfo, {
+        outdir: args.outdir,
       });
 
       await renderCode({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,10 +34,10 @@ const args = minimist(parsedCommandsAndArgv.argv, {
     'private',
   ],
   alias: {
-    outdir: 'o',
+    'outdir': 'o',
     'schema-file': 's',
-    help: 'h',
-    language: 'l',
+    'help': 'h',
+    'language': 'l',
   },
 });
 
@@ -127,11 +127,11 @@ function showSCHelp() {
 }
 
 void (async () => {
-  if (args.help && subCommand === 'cfn')  {
+  if (args.help && subCommand === 'cfn') {
     showCfnHelp();
     process.exit(1);
   }
-  if (args.help && subCommand === 'sc')  {
+  if (args.help && subCommand === 'sc') {
     showSCHelp();
     process.exit(1);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,9 +33,8 @@ export async function readResourceDefinitionFromRegistry(
 /**
  * Entry point to import CFN resource types
  *
- * @param typeName the name or ARN of the resource type
- * @param _resourceVersion the version of the resource type (ignored for now)
- * @param outdir the out folder to use (defaults to the current directory)
+ * @param typeInfo the schema and metadata information for the type
+ * @param options options for code generation
  * @returns name of the resource type
  */
 export function importResourceType(typeInfo: TypeInfo, options: ImportResourceTypeOptions): string {

--- a/src/type-info.ts
+++ b/src/type-info.ts
@@ -2,10 +2,22 @@
  * Interface to specify additional type information
  */
 export interface TypeInfo {
-  /** The name of the resource type */
+  /**
+   * The name of the resource type
+   *
+   * Looks like 'AWS::<Service>::<Resource>'.
+  */
   TypeName: string;
-  /** The URL of the source code of the resource type */
+
+  /**
+   * The URL of the source code of the resource type
+   *
+   * `undefined` if using a local schema file.
+   */
   SourceUrl?: string;
-  /** the JSOn schema of the resource type as JSON encoded string */
+
+  /**
+   * The JSON schema of the resource type as JSON encoded string
+   */
   Schema: string;
 }

--- a/src/type-info.ts
+++ b/src/type-info.ts
@@ -5,7 +5,7 @@ export interface TypeInfo {
   /** The name of the resource type */
   TypeName: string;
   /** The URL of the source code of the resource type */
-  SourceUrl: string;
+  SourceUrl?: string;
   /** the JSOn schema of the resource type as JSON encoded string */
   Schema: string;
 }


### PR DESCRIPTION
Add a `--schema-file` parameter which bypasses reading from the
CloudFormation registry, in case the schema is available offline.

(Not really testable because the changes are in `cli.ts` which is not set up to be tested)

Fixes #