### PR TITLE
fix: use the `TypeName` from CloudFormation instead of the resourceName

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ export async function readResourceDefinitionFromRegistry(
   const type = await describeResourceType(resourceName, options);
 
   return {
-    TypeName: resourceName,
+    TypeName: type.TypeName,
     Schema: type.Schema,
     SourceUrl: type.SourceUrl,
   };


### PR DESCRIPTION
This PR fixes the `TypeName` used when using ARNs to bypass the call to `cfn.listTypes` (related to #15).

When using the `resourceName` directly, cdk-import will create files with interface and class names linked to the ARN and not the `TypeName`. 

For example, cdk-import outputs an interface with this name `CfnTypeResourceC830e97710da0c9954d80ba8df021e5439e7134bGitHubGitTagProps` for the `GitHub::Tag::Props` CloudFormation  extension.

Using the `TypeName` returned by CloudFormation fixes the problem.