### PR TITLE
chore: fix node workflow version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version: 18.x
       - name: Install dependencies
         run: yarn install --check-files
       - name: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -70,7 +70,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -95,7 +95,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version: 18.x
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -70,7 +70,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -95,7 +95,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/upgrade-dev-deps-main.yml
+++ b/.github/workflows/upgrade-dev-deps-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.github/workflows/upgrade-dev-deps-main.yml
+++ b/.github/workflows/upgrade-dev-deps-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version: 18.x
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version: 18.x
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -35,7 +35,6 @@ const project = new CdklabsTypeScriptProject({
   },
   releaseToNpm: true,
 
-  workflowNodeVersion: 'lts/*',
   minNodeVersion: '16.0.0',
 
   autoApproveUpgrades: true,

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -35,7 +35,7 @@ const project = new CdklabsTypeScriptProject({
   },
   releaseToNpm: true,
 
-  workflowNodeVersion: '16.x',
+  workflowNodeVersion: 'lts/*',
   minNodeVersion: '16.0.0',
 
   autoApproveUpgrades: true,


### PR DESCRIPTION
Use the current LTS version of Node to run workflows on
