### PR TITLE
fix: addition of NPM_CONFIG_PROVENANCE leads to release failure

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -52,4 +52,8 @@ project.package.addPackageResolutions(
   '@types/babel__traverse@7.18.2',
 );
 
+// not using `npmAccess` property because projen omits values that are
+// identical to npm defaults.
+project.package.addField('publishConfig', { access: 'public' });
+
 project.synth();

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -2,6 +2,7 @@ import { CdklabsTypeScriptProject } from 'cdklabs-projen-project-types';
 
 const project = new CdklabsTypeScriptProject({
   name: 'cdk-import',
+  repository: 'https://github.com/cdklabs/cdk-import',
   projenrcTs: true,
   private: false,
   enablePRAutoMerge: true,

--- a/package.json
+++ b/package.json
@@ -71,6 +71,9 @@
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "version": "0.0.0",
   "jest": {
     "testMatch": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "cdk-import",
   "description": "Toolkit to import CFN resource types and generate L1 constructs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cdklabs/cdk-import"
+  },
   "bin": {
     "cdk-import": "lib/cli.js"
   },


### PR DESCRIPTION
Our release mechanism has been failing for a while and we are not publishing to [npm](https://www.npmjs.com/package/cdk-import). This happened after the addition of `NPM_CONFIG_PROVENANCE` in our release workflow script. It was introduced in this [PR](https://github.com/projen/projen/pull/3330) in Projen.

This was fixed in cdk8s and following similar guidance in this PR. CDK8s PR: https://github.com/cdk8s-team/cdk8s-plus/pull/3800

Also, adding `repository: https://github.com/cdklabs/cdk-import` since we also see the error,
```
npm ERR! 422 Unprocessable Entity - PUT https://registry.npmjs.org/cdk-import - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/cdklabs/cdk-import" from provenance
```
